### PR TITLE
feat: tag tertiary color

### DIFF
--- a/components/src/components/Tag/styles.css.ts
+++ b/components/src/components/Tag/styles.css.ts
@@ -81,7 +81,7 @@ export const variants = recipe({
         }),
       ]),
       secondary: atoms({
-        color: 'textSecondary',
+        color: 'textTertiary',
         backgroundColor: 'foregroundTertiary',
       }),
       red: style([


### PR DESCRIPTION
This changes the text color for the default tag to `textTertiary` instead of `textSecondary`.