### PR TITLE
feat: avatar border

### DIFF
--- a/components/src/components/Avatar/Avatar.docs.mdx
+++ b/components/src/components/Avatar/Avatar.docs.mdx
@@ -53,12 +53,27 @@ import { Avatar } from 'degen'
 
 ## Border
 
-Display a light border around the edge to define image edges on similarly colored backgrounds. Defaults to `true`.
+By default, there is a light border around the edge to define image edges on similarly colored backgrounds. This can be disabled by using the `noBorder` prop.
 
 ```tsx live=true
 <Stack direction="horizontal">
-  <Avatar src={avatars.noun97} />
-  <Avatar border={false} src={avatars.noun97} />
+  <Avatar
+    size="24"
+    src={
+      mode === 'light'
+        ? 'https://images.mirror-media.xyz/publication-images/152cd86f-45ad-4f48-8971-4dd33fde5bc1.png'
+        : 'https://images.mirror-media.xyz/publication-images/5eaba6b2-b9ee-4bea-aeac-75796d53798f.jpg'
+    }
+  />
+  <Avatar
+    noBorder
+    size="24"
+    src={
+      mode === 'light'
+        ? 'https://images.mirror-media.xyz/publication-images/152cd86f-45ad-4f48-8971-4dd33fde5bc1.png'
+        : 'https://images.mirror-media.xyz/publication-images/5eaba6b2-b9ee-4bea-aeac-75796d53798f.jpg'
+    }
+  />
 </Stack>
 ```
 

--- a/components/src/components/Avatar/Avatar.docs.mdx
+++ b/components/src/components/Avatar/Avatar.docs.mdx
@@ -51,6 +51,17 @@ import { Avatar } from 'degen'
 </Stack>
 ```
 
+## Border
+
+Display a light border around the edge to define image edges on similarly colored backgrounds. Defaults to `true`.
+
+```tsx live=true
+<Stack direction="horizontal">
+  <Avatar src={avatars.noun97} />
+  <Avatar border={false} src={avatars.noun97} />
+</Stack>
+```
+
 ## next/image
 
 If you are using Next.js and configured [`next/image`](https://nextjs.org/docs/api-reference/next/image) appropriately, you can pass it in with the `as` prop.

--- a/components/src/components/Avatar/Avatar.tsx
+++ b/components/src/components/Avatar/Avatar.tsx
@@ -8,7 +8,7 @@ export type Props = {
   as?: 'img' | React.ComponentType
   label: string
   placeholder?: boolean
-  border?: boolean
+  noBorder?: boolean
   size?: BoxProps['height']
   src?: string
 } & styles.Variants
@@ -17,7 +17,7 @@ export const Avatar = ({
   as = 'img',
   label,
   placeholder,
-  border = true,
+  noBorder,
   shape = 'circle',
   size = '12',
   src,
@@ -25,7 +25,7 @@ export const Avatar = ({
   return (
     <Box
       backgroundColor="foregroundSecondary"
-      className={styles.variants({ shape })}
+      className={styles.variants({ shape, noBorder: placeholder || noBorder })}
       height={size}
       minWidth={size}
       overflow="hidden"
@@ -57,16 +57,6 @@ export const Avatar = ({
               layout: typeof as === 'string' ? undefined : 'fill',
             }}
           />
-          {border && (
-            <Box
-              boxShadow="-px"
-              className={styles.variants({ shape })}
-              height="full"
-              pointerEvents="none"
-              position="absolute"
-              width="full"
-            />
-          )}
         </>
       )}
     </Box>

--- a/components/src/components/Avatar/Avatar.tsx
+++ b/components/src/components/Avatar/Avatar.tsx
@@ -8,6 +8,7 @@ export type Props = {
   as?: 'img' | React.ComponentType
   label: string
   placeholder?: boolean
+  border?: boolean
   size?: BoxProps['height']
   src?: string
 } & styles.Variants
@@ -16,6 +17,7 @@ export const Avatar = ({
   as = 'img',
   label,
   placeholder,
+  border = true,
   shape = 'circle',
   size = '12',
   src,
@@ -43,17 +45,29 @@ export const Avatar = ({
           </Box>
         </Box>
       ) : (
-        <Box
-          alt={label}
-          as={as}
-          height="full"
-          src={src}
-          width="full"
-          {...{
-            decoding: 'async',
-            layout: typeof as === 'string' ? undefined : 'fill',
-          }}
-        />
+        <>
+          {border && (
+            <Box
+              boxShadow="-1px"
+              className={styles.variants({ shape })}
+              height="full"
+              pointerEvents="none"
+              position="absolute"
+              width="full"
+            />
+          )}
+          <Box
+            alt={label}
+            as={as}
+            height="full"
+            src={src}
+            width="full"
+            {...{
+              decoding: 'async',
+              layout: typeof as === 'string' ? undefined : 'fill',
+            }}
+          />
+        </>
       )}
     </Box>
   )

--- a/components/src/components/Avatar/Avatar.tsx
+++ b/components/src/components/Avatar/Avatar.tsx
@@ -46,16 +46,6 @@ export const Avatar = ({
         </Box>
       ) : (
         <>
-          {border && (
-            <Box
-              boxShadow="-1px"
-              className={styles.variants({ shape })}
-              height="full"
-              pointerEvents="none"
-              position="absolute"
-              width="full"
-            />
-          )}
           <Box
             alt={label}
             as={as}
@@ -67,6 +57,16 @@ export const Avatar = ({
               layout: typeof as === 'string' ? undefined : 'fill',
             }}
           />
+          {border && (
+            <Box
+              boxShadow="-1px"
+              className={styles.variants({ shape })}
+              height="full"
+              pointerEvents="none"
+              position="absolute"
+              width="full"
+            />
+          )}
         </>
       )}
     </Box>

--- a/components/src/components/Avatar/Avatar.tsx
+++ b/components/src/components/Avatar/Avatar.tsx
@@ -59,7 +59,7 @@ export const Avatar = ({
           />
           {border && (
             <Box
-              boxShadow="-1px"
+              boxShadow="-px"
               className={styles.variants({ shape })}
               height="full"
               pointerEvents="none"

--- a/components/src/components/Avatar/styles.css.ts
+++ b/components/src/components/Avatar/styles.css.ts
@@ -1,17 +1,46 @@
+import { style } from '@vanilla-extract/css'
 import { RecipeVariants, recipe } from '@vanilla-extract/recipes'
 
-import { atoms } from '../../css'
+import { atoms, vars } from '../../css'
 
 export const variants = recipe({
   variants: {
-    shape: {
-      circle: atoms({
-        borderRadius: 'full',
-      }),
-      square: atoms({
-        borderRadius: '2xLarge',
+    noBorder: {
+      true: {},
+      false: style({
+        ':before': {
+          boxShadow: `${vars.shadows['-px']} ${vars.colors.foregroundTertiary}`,
+          content: '',
+          inset: 0,
+          position: 'absolute',
+        },
       }),
     },
+    shape: {
+      circle: style([
+        atoms({
+          borderRadius: 'full',
+        }),
+        style({
+          ':before': {
+            borderRadius: vars.radii.full,
+          },
+        }),
+      ]),
+      square: style([
+        atoms({
+          borderRadius: '2xLarge',
+        }),
+        style({
+          ':before': {
+            borderRadius: vars.radii['2xLarge'],
+          },
+        }),
+      ]),
+    },
+  },
+  defaultVariants: {
+    noBorder: false,
   },
 })
 

--- a/components/src/css/sprinkles.css.ts
+++ b/components/src/css/sprinkles.css.ts
@@ -208,9 +208,9 @@ const selectorProperties = defineProperties({
         vars: { [boxShadowColorVar]: vars.colors.foregroundSecondary },
         boxShadow: `${vars.shadows['0']} ${boxShadowColorVar}`,
       },
-      '-1px': {
+      '-px': {
         vars: { [boxShadowColorVar]: vars.colors.foregroundTertiary },
-        boxShadow: `${vars.shadows['-1px']} ${boxShadowColorVar}`,
+        boxShadow: `${vars.shadows['-px']} ${boxShadowColorVar}`,
       },
     },
     boxShadowColor: {

--- a/components/src/css/sprinkles.css.ts
+++ b/components/src/css/sprinkles.css.ts
@@ -208,15 +208,8 @@ const selectorProperties = defineProperties({
         vars: { [boxShadowColorVar]: vars.colors.foregroundSecondary },
         boxShadow: `${vars.shadows['0']} ${boxShadowColorVar}`,
       },
-      '-px': {
-        vars: { [boxShadowColorVar]: vars.colors.foregroundTertiary },
-        boxShadow: `${vars.shadows['-px']} ${boxShadowColorVar}`,
-      },
     },
     boxShadowColor: {
-      foregroundTertiary: {
-        vars: { [boxShadowColorVar]: vars.colors.foregroundTertiary },
-      },
       foregroundSecondary: {
         vars: { [boxShadowColorVar]: vars.colors.foregroundSecondary },
       },

--- a/components/src/css/sprinkles.css.ts
+++ b/components/src/css/sprinkles.css.ts
@@ -208,8 +208,15 @@ const selectorProperties = defineProperties({
         vars: { [boxShadowColorVar]: vars.colors.foregroundSecondary },
         boxShadow: `${vars.shadows['0']} ${boxShadowColorVar}`,
       },
+      '-1px': {
+        vars: { [boxShadowColorVar]: vars.colors.foregroundTertiary },
+        boxShadow: `${vars.shadows['-1px']} ${boxShadowColorVar}`,
+      },
     },
     boxShadowColor: {
+      foregroundTertiary: {
+        vars: { [boxShadowColorVar]: vars.colors.foregroundTertiary },
+      },
       foregroundSecondary: {
         vars: { [boxShadowColorVar]: vars.colors.foregroundSecondary },
       },

--- a/components/src/tokens/shadows.ts
+++ b/components/src/tokens/shadows.ts
@@ -1,6 +1,6 @@
 export const shadows = {
   none: 'none',
-  '-1px': 'inset 0 0 0 1px',
+  '-px': 'inset 0 0 0 1px',
   '0': '0 0 0 0',
   '0.5': '0 0 0 0.125rem',
   '1': '0 0 0 0.25rem',

--- a/components/src/tokens/shadows.ts
+++ b/components/src/tokens/shadows.ts
@@ -1,5 +1,6 @@
 export const shadows = {
   none: 'none',
+  '-1px': 'inset 0 0 0 1px',
   '0': '0 0 0 0',
   '0.5': '0 0 0 0.125rem',
   '1': '0 0 0 0.25rem',


### PR DESCRIPTION
This adds an optional border to avatar images. This prevents avatar images on with white backgrounds from blending with a white background, for example. Defaults to `true`. On the left is an example with a border. On the right without.

<img width="156" alt="image" src="https://user-images.githubusercontent.com/1450427/143132544-7f348b40-215e-4d22-92ad-d25f598eb153.png">
