### PR TITLE
Heading two line height

### DIFF
--- a/components/src/components/Heading/styles.css.ts
+++ b/components/src/components/Heading/styles.css.ts
@@ -19,9 +19,7 @@ const level = {
       fontSize: 'headingTwo',
       fontWeight: 'semiBold',
       letterSpacing: '-0.02',
-    }),
-    style({
-      lineHeight: '2.5rem',
+      lineHeight: '1.25',
     }),
   ]),
 }


### PR DESCRIPTION
Resolves an issue with `<Heading level="2" responsive />` line height being excessive when at the `sm` breakpoint.