### PR TITLE
Add injected style system

### DIFF
--- a/components/src/css/atoms.ts
+++ b/components/src/css/atoms.ts
@@ -2,17 +2,19 @@ import clsx from 'clsx'
 
 import * as resetStyles from './reset.css'
 import { Sprinkles, sprinkles } from './sprinkles.css'
+import { getInjectedStyleClasses } from './injectedStyles'
 
 export type Atoms = Sprinkles & {
   reset?: resetStyles.Element & keyof JSX.IntrinsicElements
 }
 
 export const atoms = ({ reset, ...rest }: Atoms) => {
-  if (!reset) return sprinkles(rest)
-
-  const elementReset = resetStyles.element[reset]
-
   const sprinklesClasses = sprinkles(rest)
+  const injectedStyleClasses = getInjectedStyleClasses(rest)
 
-  return clsx(resetStyles.base, elementReset, sprinklesClasses)
+  return clsx(
+    reset && [resetStyles.base, resetStyles.element[reset]],
+    sprinklesClasses,
+    injectedStyleClasses,
+  )
 }

--- a/components/src/css/injectedStyles.css.ts
+++ b/components/src/css/injectedStyles.css.ts
@@ -1,0 +1,43 @@
+import { createVar } from '@vanilla-extract/css'
+import { calc } from '@vanilla-extract/css-utils'
+import { recipe } from '@vanilla-extract/recipes'
+
+// https://css-tricks.com/almanac/properties/a/aspect-ratio/
+const aspectRatioVar = createVar()
+export const aspectRatioFallback = recipe({
+  base: {
+    '@supports': {
+      'not (aspect-ratio: 1 / 1)': {
+        ':before': {
+          float: 'left',
+          paddingTop: calc.multiply(calc.divide(1, aspectRatioVar), '100%'),
+          content: '',
+        },
+        ':after': {
+          display: 'block',
+          content: '',
+          clear: 'both',
+        },
+      },
+    },
+  },
+  variants: {
+    ratio: {
+      '1/1': {
+        vars: { [aspectRatioVar]: 'calc(1 / 1)' },
+      },
+      '2/1': {
+        vars: { [aspectRatioVar]: 'calc(2 / 1)' },
+      },
+      '4/1': {
+        vars: { [aspectRatioVar]: 'calc(4 / 1)' },
+      },
+      '4/3': {
+        vars: { [aspectRatioVar]: 'calc(4 / 3)' },
+      },
+      '16/9': {
+        vars: { [aspectRatioVar]: 'calc(16 / 9)' },
+      },
+    },
+  },
+})

--- a/components/src/css/injectedStyles.ts
+++ b/components/src/css/injectedStyles.ts
@@ -1,0 +1,27 @@
+import { aspectRatioFallback } from './injectedStyles.css'
+import { Sprinkles } from './sprinkles.css'
+
+const injectedStyleRules = ['aspectRatio'] as const
+
+export const getInjectedStyleClasses = (rules: Sprinkles): Array<string> => {
+  const injectedStyleClasses: Array<string> = []
+
+  for (const rule of injectedStyleRules) {
+    switch (rule) {
+      case 'aspectRatio': {
+        const value = rules[rule]
+        if (value && value !== 'auto') {
+          injectedStyleClasses.push(aspectRatioFallback({ ratio: value }))
+        }
+        break
+      }
+      default: {
+        // Ensures a typesafe exhaustive check
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const exhaustiveCheck: never = rule
+      }
+    }
+  }
+
+  return injectedStyleClasses
+}


### PR DESCRIPTION
This PR adds a new system to inject styles to the `atoms` function depending on the content passed in.

The first use case of this is to add an aspect ratio fallback rule if the `aspectRatio` rule is passed in.

| before | after |
| - | - |
| <img width="536" src="https://user-images.githubusercontent.com/4934193/150427524-b7b826fa-e4e4-4780-ae7a-07478bcc83ec.png">| <img width="542" src="https://user-images.githubusercontent.com/4934193/150427541-ce020e15-b6a7-4444-b50c-4ebbc2d1b861.png"> |