### PR TITLE
Extend card options

### DIFF
--- a/components/src/components/Card/Card.tsx
+++ b/components/src/components/Card/Card.tsx
@@ -8,6 +8,8 @@ type Props = {
   as?: BoxProps['as']
   shadow?: boolean
   hover?: boolean
+  level?: '1' | '2'
+  borderRadius?: BoxProps['borderRadius']
   padding?: BoxProps['padding']
   width?: BoxProps['width']
 }
@@ -17,15 +19,19 @@ export const Card = ({
   children,
   padding,
   shadow,
+  level = '1',
   hover,
+  borderRadius = { xs: '2xLarge', sm: '3xLarge' },
   width,
 }: React.PropsWithChildren<Props>) => {
   const { mode, forcedMode } = useTheme()
   return (
     <Box
       as={as}
+      borderRadius={borderRadius}
       className={styles.variants({
         dark: (forcedMode ?? mode) === 'dark',
+        level,
         shadow,
         hover,
       })}

--- a/components/src/components/Card/styles.css.ts
+++ b/components/src/components/Card/styles.css.ts
@@ -6,22 +6,7 @@ import { atoms, responsiveStyle, rgb, vars } from '../../css'
 const radiiVar = createVar()
 
 export const variants = recipe({
-  base: [
-    atoms({
-      borderRadius: { xs: '2xLarge', sm: '3xLarge' },
-    }),
-  ],
   variants: {
-    dark: {
-      true: atoms({
-        backgroundColor: 'black',
-      }),
-      false: style([
-        atoms({
-          backgroundColor: 'white',
-        }),
-      ]),
-    },
     hover: {
       true: style([
         atoms({
@@ -42,12 +27,40 @@ export const variants = recipe({
       ]),
       false: {},
     },
+    level: {
+      '1': {},
+      '2': atoms({
+        backgroundColor: 'background',
+      }),
+    },
+    dark: {
+      true: {},
+      false: {},
+    },
     shadow: {
       true: {},
       false: {},
     },
   },
   compoundVariants: [
+    {
+      variants: {
+        dark: true,
+        level: '1',
+      },
+      style: atoms({
+        backgroundColor: 'black',
+      }),
+    },
+    {
+      variants: {
+        dark: false,
+        level: '1',
+      },
+      style: atoms({
+        backgroundColor: 'white',
+      }),
+    },
     {
       variants: {
         dark: false,


### PR DESCRIPTION
Adds an option for a custom `borderRadius` and `level` which is used when cards are nested within `foregroundTertiary` containers.