### PR TITLE
Expose address in avatar group

### DIFF
--- a/components/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/components/src/components/AvatarGroup/AvatarGroup.tsx
@@ -12,6 +12,7 @@ type Props = {
     label: AvatarProps['label']
     placeholder?: AvatarProps['placeholder']
     src?: AvatarProps['src']
+    address?: AvatarProps['address']
   }[]
   size?: BoxProps['height']
   tag?: string


### PR DESCRIPTION
Oops, forgot to include in prior release

- Allows an address to be set for individual Avatars via AvatarGroup