### PR TITLE
fix text for primary tag color

### DIFF
--- a/components/src/components/Tag/styles.css.ts
+++ b/components/src/components/Tag/styles.css.ts
@@ -62,7 +62,7 @@ export const variants = recipe({
     },
     tone: {
       primary: atoms({
-        color: 'white',
+        color: 'accentText',
         backgroundColor: 'accent',
       }),
       accent: atoms({


### PR DESCRIPTION
before

<img width="500" alt="Screenshot 2023-09-20 at 12 04 59 PM" src="https://github.com/mirror-xyz/degen/assets/4934193/ce527406-f52e-4601-b14a-656e47b7afb7">

after

<img width="500" alt="Screenshot 2023-09-20 at 12 07 24 PM" src="https://github.com/mirror-xyz/degen/assets/4934193/2eaa5694-a541-46b5-a6bb-b1af2b567d77">
